### PR TITLE
licensekey.dat, ts3server.sqlitedb, updated link, verify hash

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,29 @@ teamspeak:
 
   install_master: false
   install_dns: true
+  import_sqlitedb: false
+
+  license: |
+    Company name : XXX
+    address      : XXX
+    address2     : XXX
+    zipcode      : XXX
+    city         : XXX
+    country      : XXX
+    phone        : XXX
+    fax          : XXX
+    sales contact: XXX
+    tech contact : XXX
+
+    type         : XXX
+    start date   : XXX
+    end date     : XXX
+    max. virtual servers: XXX
+    max. slots   : XXX
+    description  : XXX
+
+    ==key==
+    XXX
 
   ini_options:
     serveradmin_password: xxx

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,10 @@ teamspeak:
   install_dns: true
   import_sqlitedb: false
 
+  archive:
+    source: http://dl.4players.de/ts/releases/3.0.13.8/teamspeak3-server_linux_amd64-3.0.13.8.tar.bz2
+    source_hash: 460c771bf58c9a49b4be2c677652f21896b98a021d7fff286e59679b3f987a59
+
   license: |
     Company name : XXX
     address      : XXX

--- a/teamspeak/defaults.yaml
+++ b/teamspeak/defaults.yaml
@@ -16,3 +16,5 @@ teamspeak:
   enable_dns: false
   dns_executable: tsdns
   tsdns_ini_options: {}
+
+  import_sqlitedb: false

--- a/teamspeak/defaults.yaml
+++ b/teamspeak/defaults.yaml
@@ -4,8 +4,7 @@ teamspeak:
   user: teamspeak
   group: teamspeak
 
-  archive: http://dl.4players.de/ts/releases/3.0.13.8/teamspeak3-server_linux_amd64-3.0.13.8.tar.bz2
-  archive_hash: 460c771bf58c9a49b4be2c677652f21896b98a021d7fff286e59679b3f987a59
+  archive: http://dl.4players.de/ts/releases/3.0.13.4/teamspeak3-server_freebsd_amd64-3.0.13.4.tar.bz2
 
   executable: ts3server
   ini_options: {}

--- a/teamspeak/defaults.yaml
+++ b/teamspeak/defaults.yaml
@@ -4,7 +4,9 @@ teamspeak:
   user: teamspeak
   group: teamspeak
 
-  archive: http://dl.4players.de/ts/releases/3.0.13.4/teamspeak3-server_freebsd_amd64-3.0.13.4.tar.bz2
+  archive:
+    source: http://dl.4players.de/ts/releases/3.0.13.8/teamspeak3-server_linux_amd64-3.0.13.8.tar.bz2
+    source_hash: 460c771bf58c9a49b4be2c677652f21896b98a021d7fff286e59679b3f987a59
 
   executable: ts3server
   ini_options: {}

--- a/teamspeak/defaults.yaml
+++ b/teamspeak/defaults.yaml
@@ -4,7 +4,8 @@ teamspeak:
   user: teamspeak
   group: teamspeak
 
-  archive: http://dl.4players.de/ts/releases/3.0.13.4/teamspeak3-server_freebsd_amd64-3.0.13.4.tar.bz2
+  archive: http://dl.4players.de/ts/releases/3.0.13.8/teamspeak3-server_linux_amd64-3.0.13.8.tar.bz2
+  archive_hash: 460c771bf58c9a49b4be2c677652f21896b98a021d7fff286e59679b3f987a59
 
   executable: ts3server
   ini_options: {}

--- a/teamspeak/files/teamspeak.service
+++ b/teamspeak/files/teamspeak.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=TeamSpeak 3 Server
+After=network.service
+
+[Service]
+User={{ user }}
+Group={{ group }}
+Type=forking
+WorkingDirectory={{ directory }}
+ExecStart={{ directory }}/ts3server_startscript.sh start
+ExecStop={{ directory }}/ts3server_startscript.sh stop
+PIDFile={{ directory }}/ts3server.pid
+RestartSec=15
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/teamspeak/init.sls
+++ b/teamspeak/init.sls
@@ -1,5 +1,4 @@
 {% from 'teamspeak/map.jinja' import teamspeak with context %}
-{% from 'teamspeak/macros.jinja' import sls_block with context %}
 
 teamspeak_user:
   user.present:
@@ -25,7 +24,8 @@ teamspeak_archive:
     - group: {{ teamspeak.group }}
     - require:
       - file: teamspeak_directory
-    {{ sls_block(teamspeak.archive) | indent(4) }}
+    - source: {{ teamspeak.archive | yaml_encode }}
+    - source_hash: {{ teamspeak.archive_hash }}
 
   cmd.run:
     - name: tar xf archive.tgz --strip-components=1

--- a/teamspeak/init.sls
+++ b/teamspeak/init.sls
@@ -49,6 +49,8 @@ teamspeak_ini:
 teamspeak_license:
     file.managed:
       - name: {{ teamspeak.directory }}/licensekey.dat
+      - user: {{ teamspeak.user }}
+      - group: {{ teamspeak.group }}
       - mode: 600
       - contents_pillar: teamspeak:license
 {% endif %}
@@ -57,6 +59,8 @@ teamspeak_license:
 teamspeak_sqlitedb:
   file.managed:
     - name: {{ teamspeak.directory }}/ts3server.sqlitedb
+    - user: {{ teamspeak.user }}
+    - group: {{ teamspeak.group }}
     - source: salt://teamspeak/files/ts3server.sqlitedb
     - mode: 640
     - require:

--- a/teamspeak/init.sls
+++ b/teamspeak/init.sls
@@ -88,7 +88,7 @@ teamspeak_service:
 {% endif %}
 {% else %}
 {% if grains['systemd'] %}
-teamspeak_service:
+teamspeak_service_config:
   file.managed:
     - name: /etc/systemd/system/teamspeak.service
     - source: salt://teamspeak/files/teamspeak.service

--- a/teamspeak/init.sls
+++ b/teamspeak/init.sls
@@ -86,6 +86,32 @@ teamspeak_service:
 {% if teamspeak.enable_master %}
       - service: teamspeak_master_service
 {% endif %}
+{% else %}
+{% if grains['systemd'] %}
+teamspeak_service:
+  file.managed:
+    - name: /etc/systemd/system/teamspeak.service
+    - source: salt://teamspeak/files/teamspeak.service
+    - template: jinja
+    - mode: 755
+    - defaults:
+        directory: {{ teamspeak.directory | yaml_encode }}
+        user: {{ teamspeak.user | yaml_encode }}
+        group: {{ teamspeak.group | yaml_encode }}
+        executable: {{ teamspeak.executable | yaml_encode }}
+    - require:
+      - file: teamspeak_ini
+
+teamspeak_service:
+  service.running:
+    - name: teamspeak
+    - enable: true
+    - require:
+      - cmd: teamspeak_archive
+{% if teamspeak.enable_master %}
+      - service: teamspeak_master_service
+{% endif %}
+{% endif %}
 {% endif %}
 
 {% if teamspeak.enable_master or teamspeak.enable_dns %}

--- a/teamspeak/init.sls
+++ b/teamspeak/init.sls
@@ -1,4 +1,5 @@
 {% from 'teamspeak/map.jinja' import teamspeak with context %}
+{% from 'teamspeak/macros.jinja' import sls_block with context %}
 
 teamspeak_user:
   user.present:
@@ -24,8 +25,7 @@ teamspeak_archive:
     - group: {{ teamspeak.group }}
     - require:
       - file: teamspeak_directory
-    - source: {{ teamspeak.archive | yaml_encode }}
-    - source_hash: {{ teamspeak.archive_hash }}
+    {{ sls_block(teamspeak.archive) | indent(4) }}
 
   cmd.run:
     - name: tar xf archive.tgz --strip-components=1

--- a/teamspeak/init.sls
+++ b/teamspeak/init.sls
@@ -45,6 +45,24 @@ teamspeak_ini:
     - require:
       - cmd: teamspeak_archive
 
+{% if teamspeak.license %}
+teamspeak_license:
+    file.managed:
+      - name: {{ teamspeak.directory }}/licensekey.dat
+      - mode: 600
+      - contents_pillar: teamspeak:license
+{% endif %}
+
+{% if teamspeak.import_sqlitedb %}
+teamspeak_sqlitedb:
+  file.managed:
+    - name: {{ teamspeak.directory }}/ts3server.sqlitedb
+    - source: salt://teamspeak/files/ts3server.sqlitedb
+    - mode: 640
+    - require:
+        - cmd: teamspeak_archive
+{% endif %}
+
 {% if grains.os_family == 'FreeBSD' %}
 teamspeak_init_script:
   file.managed:
@@ -70,10 +88,12 @@ teamspeak_service:
 {% endif %}
 {% endif %}
 
+{% if teamspeak.enable_master or teamspeak.enable_dns %}
 include:
 {% if teamspeak.enable_master %}
   - teamspeak.master
 {% endif %}
 {% if teamspeak.enable_dns %}
   - teamspeak.dns
+{% endif %}
 {% endif %}

--- a/teamspeak/macros.jinja
+++ b/teamspeak/macros.jinja
@@ -1,0 +1,5 @@
+{% macro sls_block(dict) %}
+{% for key, value in dict.items() %}
+- {{ key }}: {{ value|json() }}
+{% endfor %}
+{% endmacro %}

--- a/teamspeak/macros.jinja
+++ b/teamspeak/macros.jinja
@@ -1,5 +1,0 @@
-{% macro sls_block(dict) %}
-{% for key, value in dict.items() %}
-- {{ key }}: {{ value|json() }}
-{% endfor %}
-{% endmacro %}


### PR DESCRIPTION
Hey!

A few changes:

- This formula now manages a licensekey.dat, if provided in pillars.
- The sls_block macro caused a syntax error for me, so I removed it and simplified it to source
- While changing that, I added archive_hash to verify the hash of the downloaded archive
- I also updated the link to an up-to-date version of ts3server
- Install a systemd .service on systems running systemd